### PR TITLE
Set dependency "SwiftCLI" to be upToNextMinor(from: "5.2.2")

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/kylef/PathKit.git",
         "state": {
           "branch": null,
-          "revision": "891a3fec2699fc43aed18b7649950677c0152a22",
-          "version": "0.8.0"
+          "revision": "e2f5be30e4c8f531c9c1e8765aa7b71c0a45d7a0",
+          "version": "0.9.2"
         }
       },
       {
@@ -33,8 +33,8 @@
         "repositoryURL": "https://github.com/kylef/Spectre.git",
         "state": {
           "branch": null,
-          "revision": "e46b75cf03ad5e563b4b0a5068d3d6f04d77d80b",
-          "version": "0.7.2"
+          "revision": "f14ff47f45642aa5703900980b014c2e9394b6e5",
+          "version": "0.9.0"
         }
       },
       {
@@ -51,8 +51,8 @@
         "repositoryURL": "https://github.com/jakeheis/SwiftCLI",
         "state": {
           "branch": null,
-          "revision": "51ba542611878b2e64e82467b895fdf4240ec32e",
-          "version": "5.0.0"
+          "revision": "5318c37d3cacc8780f50b87a8840a6774320ebdf",
+          "version": "5.2.2"
         }
       },
       {
@@ -60,8 +60,8 @@
         "repositoryURL": "https://github.com/jpsim/Yams.git",
         "state": {
           "branch": null,
-          "revision": "95f45caf07472ec78223ebada45255086a85b01a",
-          "version": "0.5.0"
+          "revision": "6652aa7b793d3c8a075db0614acb575fcaecf457",
+          "version": "0.7.0"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -10,7 +10,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/kylef/PathKit.git", from: "0.8.0"),
-        .package(url: "https://github.com/jakeheis/SwiftCLI", from: "5.0.0"),
+        .package(url: "https://github.com/jakeheis/SwiftCLI", .upToNextMinor(from: "5.2.2")),
         .package(url: "https://github.com/stencilproject/Stencil.git", from: "0.13.0"),
         .package(url: "https://github.com/jpsim/Yams.git", from: "0.5.0"),
         .package(url: "https://github.com/yonaskolb/JSONUtilities.git", from: "4.1.0"),


### PR DESCRIPTION
SwiftCLI should be below 5.2.2 otherwise it won't compile due to a variable name change.